### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,11 +11,3 @@ Welcome to the asi_core documentation!
    :caption: Contents:
 
    manual/index
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
This PR removes the listing at the bottom of the documentation page. This really isn't that useful and mostly just clutters the documentation page.